### PR TITLE
GYM-227/230: registration fails with an already registered email and back/next button behaviour

### DIFF
--- a/e2e/pages/register.page.ts
+++ b/e2e/pages/register.page.ts
@@ -62,7 +62,7 @@ export class RegisterPage {
     await this.lastNameInput.fill(lastName);
     await this.nextButton.click();
   }
-  async stepThreeRegister(): Promise<void> {
+  async submitRegistration(): Promise<void> {
     // Optional you can add Location and Bio
     await this.registerButton.click();
   }
@@ -102,6 +102,6 @@ export class RegisterPage {
     await this.backButton.click();
     await expect(this.emailInput).toHaveValue(email);
     await expect(this.passwordInput).toHaveValue(password);
-    await expect(this.passwordInput).toHaveValue(password);
+    await expect(this.confirmPasswordInput).toHaveValue(password);
   }
 }

--- a/e2e/pages/register.page.ts
+++ b/e2e/pages/register.page.ts
@@ -5,6 +5,7 @@ export class RegisterPage {
   passwordInput: Locator;
   confirmPasswordInput: Locator;
   nextButton: Locator;
+  backButton: Locator;
   emailError: Locator;
   passwordError: Locator;
   confirmPasswordError: Locator;
@@ -16,21 +17,32 @@ export class RegisterPage {
   firstNameError: Locator;
   lastNameError: Locator;
 
-  constructor(private page: Page) {
-    this.emailInput = this.page.locator('#\\:r1\\:');
-    this.passwordInput = this.page.locator('#\\:r3\\:');
-    this.confirmPasswordInput = this.page.locator('#\\:r7\\:');
-    this.nextButton = this.page.getByTestId('next-button');
-    this.emailError = this.page.locator('#\\:r1\\:-helper-text');
-    this.passwordError = this.page.locator('#\\:r3\\:-helper-text');
-    this.confirmPasswordError = this.page.locator('#\\:r7\\:-helper-text');
+  locationInput: Locator;
+  bioInput: Locator;
+  registerButton: Locator;
+  userAlreadyExistsAlert: Locator;
 
-    this.usernameInput = this.page.locator('#\\:rb\\:');
-    this.firstNameInput = this.page.locator('#\\:rd\\:');
-    this.lastNameInput = this.page.locator('#\\:rf\\:');
-    this.usernameError = this.page.locator('#\\:rb\\:-helper-text');
-    this.firstNameError = this.page.locator('#\\:rd\\:-helper-text');
-    this.lastNameError = this.page.locator('#\\:rf\\:-helper-text');
+  constructor(private page: Page) {
+    this.emailInput = this.page.getByRole('textbox', { name: 'Email adress' });
+    this.passwordInput = this.page.getByRole('textbox', { name: 'Password', exact: true });
+    this.confirmPasswordInput = this.page.getByRole('textbox', { name: 'Confirm password', exact: true });
+    this.nextButton = this.page.getByTestId('next-button');
+    this.backButton = this.page.getByTestId('back-button');
+    this.emailError = this.page.getByText('Email is required');
+    this.passwordError = this.page.getByText('Password is required');
+    this.confirmPasswordError = this.page.getByText('Passwords do not match');
+
+    this.usernameInput = this.page.getByRole('textbox', { name: 'Username' });
+    this.firstNameInput = this.page.getByRole('textbox', { name: 'First Name' });
+    this.lastNameInput = this.page.getByRole('textbox', { name: 'Last Name' });
+    this.usernameError = this.page.getByText('Username is required');
+    this.firstNameError = this.page.getByText('First name is required');
+    this.lastNameError = this.page.getByText('Last name is required');
+
+    this.locationInput = this.page.getByRole('textbox', { name: 'Location (Optional)' });
+    this.bioInput = this.page.getByRole('textbox', { name: 'Bio (Optional)' });
+    this.registerButton = this.page.getByTestId('register-button');
+    this.userAlreadyExistsAlert = this.page.getByText('User already exists');
   }
 
   async expectToBeOnRegisterPage() {
@@ -50,6 +62,10 @@ export class RegisterPage {
     await this.lastNameInput.fill(lastName);
     await this.nextButton.click();
   }
+  async stepThreeRegister(): Promise<void> {
+    // Optional you can add Location and Bio
+    await this.registerButton.click();
+  }
   async expectEmailIsRequiredError() {
     await expect(this.emailError).toHaveText('Email is required');
   }
@@ -67,5 +83,25 @@ export class RegisterPage {
   }
   async expectLastNameIsRequiredError() {
     await expect(this.lastNameError).toHaveText('Last name is required');
+  }
+  async expectUserAlreadyExistsAlert() {
+    await expect(this.userAlreadyExistsAlert).toBeVisible();
+  }
+  async expectBackButtonIsDisabled() {
+    await expect(this.backButton).toBeDisabled();
+  }
+  async expectLocationBioFieldsAreVisible() {
+    await expect(this.locationInput).toBeVisible();
+    await expect(this.bioInput).toBeVisible();
+  }
+  async expectPreviousEnteredDataIsVisible(email: string, password: string, username: string, firstName: string, lastName: string) {
+    await this.backButton.click();
+    await expect(this.usernameInput).toHaveValue(username);
+    await expect(this.firstNameInput).toHaveValue(firstName);
+    await expect(this.lastNameInput).toHaveValue(lastName);
+    await this.backButton.click();
+    await expect(this.emailInput).toHaveValue(email);
+    await expect(this.passwordInput).toHaveValue(password);
+    await expect(this.passwordInput).toHaveValue(password);
   }
 }

--- a/e2e/test-data/register.data.ts
+++ b/e2e/test-data/register.data.ts
@@ -1,8 +1,8 @@
 export const registerData = {
+    registeredEmail: 'sourcery.graduates@gmail.com',
     userEmail: 'user@test.com',
     userPassword: 'password',
     userUsername: 'user',
     userFirstName: 'John',
     userLastName: 'Doe',
-    
 }

--- a/e2e/test-data/register.data.ts
+++ b/e2e/test-data/register.data.ts
@@ -1,5 +1,4 @@
 export const registerData = {
-    registeredEmail: 'sourcery.graduates@gmail.com',
     userEmail: 'user@test.com',
     userPassword: 'password',
     userUsername: 'user',

--- a/e2e/tests/authentication/register.spec.ts
+++ b/e2e/tests/authentication/register.spec.ts
@@ -6,6 +6,7 @@ import { LoginPage } from '../../pages/login.page';
 test.describe('Registration tests', async () => {
   let registerPage: RegisterPage;
   let loginPage: LoginPage;
+  const registeredEmail = registerData.registeredEmail;
   const testEmail = registerData.userEmail;
   const testPassword = registerData.userPassword;
   const testUsername = registerData.userUsername;
@@ -74,4 +75,19 @@ test.describe('Registration tests', async () => {
     // Assert
     await registerPage.expectLastNameIsRequiredError();
   });
+
+  test('registration fails with already registered email', async () => {
+    await registerPage.stepOneRegister(registeredEmail, testPassword, testPassword);
+    await registerPage.stepTwoRegister(testUsername, testFirstName, testLastName);
+    await registerPage.stepThreeRegister();
+    await registerPage.expectUserAlreadyExistsAlert();
+  });
+  
+  test('registration - Back/Next button behaviour', async () => {
+    await registerPage.expectBackButtonIsDisabled();
+    await registerPage.stepOneRegister(testEmail, testPassword, testPassword);
+    await registerPage.stepTwoRegister(testUsername, testFirstName, testLastName);
+    await registerPage.expectLocationBioFieldsAreVisible();
+    await registerPage.expectPreviousEnteredDataIsVisible(testEmail, testPassword, testUsername, testFirstName, testLastName);
+  })
 });

--- a/e2e/tests/authentication/register.spec.ts
+++ b/e2e/tests/authentication/register.spec.ts
@@ -6,7 +6,6 @@ import { LoginPage } from '../../pages/login.page';
 test.describe('Registration tests', async () => {
   let registerPage: RegisterPage;
   let loginPage: LoginPage;
-  const registeredEmail = registerData.registeredEmail;
   const testEmail = registerData.userEmail;
   const testPassword = registerData.userPassword;
   const testUsername = registerData.userUsername;
@@ -77,9 +76,9 @@ test.describe('Registration tests', async () => {
   });
 
   test('registration fails with already registered email', async () => {
-    await registerPage.stepOneRegister(registeredEmail, testPassword, testPassword);
+    await registerPage.stepOneRegister(process.env.USER_EMAIL!, testPassword, testPassword);
     await registerPage.stepTwoRegister(testUsername, testFirstName, testLastName);
-    await registerPage.stepThreeRegister();
+    await registerPage.submitRegistration();
     await registerPage.expectUserAlreadyExistsAlert();
   });
   

--- a/src/app/pages/registerPage/RegisterPage.tsx
+++ b/src/app/pages/registerPage/RegisterPage.tsx
@@ -248,12 +248,12 @@ const RegisterPage = () => {
           )}
 
           <Box sx={{ display: 'flex', flexDirection: 'row', pt: 2 }}>
-            <Button isDisabled={activeStep === 0} type='button' onClick={handleBack}>
+            <Button isDisabled={activeStep === 0} type='button' onClick={handleBack} dataTestId='back-button'>
               Back
             </Button>
             <Box sx={{ flex: '1 1 auto' }} />
             {activeStep === steps.length - 1 ? (
-              <Button type='submit' isDisabled={activeStep !== steps.length - 1}>
+              <Button type='submit' isDisabled={activeStep !== steps.length - 1} dataTestId='register-button'>
                 Register
               </Button>
             ) : (


### PR DESCRIPTION
Add test case for registration with an already registered email.
[GYM-227 Jira ticket](https://sourcery-graduates.atlassian.net/browse/GYM-227?atlOrigin=eyJpIjoiYjIwZWU4OTg3NDkxNGMyZmIzMGVkNTNlNGRiN2RlMjAiLCJwIjoiaiJ9)
Add test the behaviour of the Back/Next button during registration and validate that previously entered data remains visible.
[GYM-230 Jira ticket](https://sourcery-graduates.atlassian.net/browse/GYM-230?atlOrigin=eyJpIjoiYmZhNjhhMTA0ZmQyNGI2ZjllODgxZDhkOTc0OGY4NWQiLCJwIjoiaiJ9)